### PR TITLE
Scenarios

### DIFF
--- a/client/src/components/Shop.js
+++ b/client/src/components/Shop.js
@@ -88,10 +88,10 @@ const Shop = () => {
 
           <div className='col-2'>
             <div className="card text-center">
-              <h5 className="card-header">Pepe the Adventurer {`Adventurer #: ${order + 1}`}</h5>
+              <h5 className="card-header">{adventurer.name} {`Adventurer #: ${order + 1}`}</h5>
               <img src={Sprites[adventurer.occupation].img} alt={Sprites[adventurer.occupation].alt} className="knight mx-auto"/>
               <div className="card-body">
-                <p className="card-text">Would yer like to sell me some of yer potions?</p>
+                <p className="card-text">{adventurer.dialogue}</p>
                 <div className='row'>
                   <div className='col'>
                     <button type="button" onClick={handlePotionSelling} className="btn btn-primary btn-block">Sell</button>

--- a/client/src/components/Shop.js
+++ b/client/src/components/Shop.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import background from '../assets/backgrounds/shop.png';
 import Potions from './potions-list/Potions';
 import Sprites from '../assets/sprites';
@@ -6,6 +7,8 @@ import generateScenario from '../utils/scenario_generator';
 import Navigation from './nav-header/Navigation';
 
 const Shop = () => {
+  // Navigate to set path `/path`
+  const navigate = useNavigate();
 
   const style = {
     backgroundImage: `url(${background})`,
@@ -78,6 +81,9 @@ const Shop = () => {
     // Reset currently selected potion and increment the scenario to the next patron
     setPotion({ _id: '', potionName: '', desc: '', owned: 0 });
     setOrder(order + 1);
+
+    // Exit the shop and return to Main Menu if there are no more patrons left
+    if (order >= scenarioPatrons.length - 1) navigate('/main');
   }
 
   return (

--- a/client/src/components/Shop.js
+++ b/client/src/components/Shop.js
@@ -86,6 +86,16 @@ const Shop = () => {
     if (order >= scenarioPatrons.length - 1) navigate('/main');
   }
 
+  const handlePotionDecline = () =>
+  {
+    // Reset currently selected potion and increment the scenario to the next patron
+    setPotion({ _id: '', potionName: '', desc: '', owned: 0 });
+    setOrder(order + 1);
+
+    // Exit the shop and return to Main Menu if there are no more patrons left
+    if (order >= scenarioPatrons.length - 1) navigate('/main');
+  }
+
   return (
     <div className="container" style={style}>
       <Navigation />
@@ -94,7 +104,7 @@ const Shop = () => {
 
           <div className='col-2'>
             <div className="card text-center">
-              <h5 className="card-header">{adventurer.name} {`Adventurer #: ${order + 1}`}</h5>
+              <h5 className="card-header">{adventurer.name} the {adventurer.occupation.charAt(0).toUpperCase() + adventurer.occupation.slice(1)} {`Adventurer #: ${order + 1}`}</h5>
               <img src={Sprites[adventurer.occupation].img} alt={Sprites[adventurer.occupation].alt} className="knight mx-auto"/>
               <div className="card-body">
                 <p className="card-text">{adventurer.dialogue}</p>
@@ -103,7 +113,7 @@ const Shop = () => {
                     <button type="button" onClick={handlePotionSelling} className="btn btn-primary btn-block">Sell</button>
                   </div>
                   <div className='col'>
-                    <button type="button" className="btn btn-danger btn-block">Deny</button>
+                    <button type="button" onClick={handlePotionDecline} className="btn btn-danger btn-block">Deny</button>
                   </div>
                 </div>
               </div>

--- a/client/src/components/Shop.js
+++ b/client/src/components/Shop.js
@@ -16,6 +16,7 @@ const Shop = () => {
     height: '100vh',
   };
 
+  // TODO: Query for all of a user's potions
   const data = [
     {
       _id: '1',
@@ -49,9 +50,35 @@ const Shop = () => {
     }
   ];
 
+  // Sum total potions owned upon page load and generate scenario based on total potions owned
+  const TOTAL_POTIONS_OWNED = data.reduce((num_owned, potion) => num_owned + potion.owned, 0);
+  const scenarioPatrons = generateScenario(TOTAL_POTIONS_OWNED);
+
+  // Hold the scenario data and track order of patrons in scenario
+  const scenario = React.useRef(scenarioPatrons);
+  const [order, setOrder] = useState(0);
+
+  // Track current adventurer, starting at the scenario's first patron
+  const [adventurer, setAdventurer] = useState(scenario.current[0]);
+
   // Track selected potion
   const [selectedPotion, setPotion] = useState({ _id: '', potionName: '', desc: '', owned: 0 });
   const handlePotionSelection = (potion) => setPotion(potion);
+
+  console.log('scenario: ', scenario, '\n', 'order: ', order, '\n', 'adventurer: ', adventurer, '\n');
+
+  // Move to next adventurer in the scenario when the order has been changed
+  React.useEffect(() => setAdventurer(scenario.current[order]), [order]);
+
+  const handlePotionSelling = () =>
+  {
+    // Check that there are sufficient potions to sell
+    if (selectedPotion.owned < 1) return;
+
+    // Reset currently selected potion and increment the scenario to the next patron
+    setPotion({ _id: '', potionName: '', desc: '', owned: 0 });
+    setOrder(order + 1);
+  }
 
   return (
     <div className="container" style={style}>
@@ -61,13 +88,13 @@ const Shop = () => {
 
           <div className='col-2'>
             <div className="card text-center">
-              <h5 className="card-header">Pepe the Adventurer</h5>
-              <img src={Sprites['knight'].img} alt={Sprites['knight'].alt} className="knight mx-auto"/>
+              <h5 className="card-header">Pepe the Adventurer {`Adventurer #: ${order + 1}`}</h5>
+              <img src={Sprites[adventurer.occupation].img} alt={Sprites[adventurer.occupation].alt} className="knight mx-auto"/>
               <div className="card-body">
                 <p className="card-text">Would yer like to sell me some of yer potions?</p>
                 <div className='row'>
                   <div className='col'>
-                    <button type="button" className="btn btn-primary btn-block">Sell</button>
+                    <button type="button" onClick={handlePotionSelling} className="btn btn-primary btn-block">Sell</button>
                   </div>
                   <div className='col'>
                     <button type="button" className="btn btn-danger btn-block">Deny</button>

--- a/client/src/utils/scenario_generator.js
+++ b/client/src/utils/scenario_generator.js
@@ -1,17 +1,59 @@
 
 class Adventurer
 {
-    constructor(occupation)
+    constructor(name, occupation, dialogue)
     {
+        this.name = name;
         this.occupation = occupation;
+        this.dialogue = dialogue;
     }
 }
 
-const knight = new Adventurer('knight');
-const mage = new Adventurer('mage');
-const rogue = new Adventurer('rogue');
+const occupations = ['knight', 'mage', 'rogue'];
 
-const Adventurers = [knight, mage, rogue];
+const names =
+{
+    knight:
+    [
+        'Hagrid',
+        'Aragorn',
+        'Zorya'
+    ],
+    mage:
+    [
+        'Trinity',
+        'Alice',
+        'Furiosa'
+    ],
+    rogue:
+    [
+        'Han',
+        'Leon',
+        'Denton'
+    ]
+}
+
+const dialogue_options =
+{
+    knight:
+    [
+        'Would yer like to sell me some of yer potions?',
+        'Me strong, but would like to be more strong!',
+        'Any potions for a mighty warrior such as myself?'
+    ],
+    mage:
+    [
+        'Kind potion seller, would you sell me your strongest potions?',
+        'Please! I am in need of potions to boost my wits!',
+        `I'd like to cast some more spells, would you happen to have just the right brew?`
+    ],
+    rogue:
+    [
+        'Hey, pal. Got any of those potions for sneaky types like me?',
+        `I'd like some potions, preferably the stealthy variety...if you catch my drift.`,
+        `Psst, any potions for sale there, boss?`
+    ]
+};
 
 function generateScenario(potionsOwnedSum)
 {
@@ -31,9 +73,18 @@ function generateScenario(potionsOwnedSum)
 
     for (let i = 0 ; i < numPatrons ; i++)
     {
-        // Generate a random index for adventurer from 0 to 2
-        let patron_index = generateRandomNum(3);
-        let adventurer = Adventurers[patron_index];
+        // Generate a random adventurer occupation
+        let occupation_index = generateRandomNum(occupations.length);
+        let occupation = occupations[occupation_index];
+
+        // Generate a random name and dialogue option from the occupation
+        let name_index = generateRandomNum(names[occupation].length);
+        let name = names[occupation][name_index];
+        let dialogue_index = generateRandomNum(dialogue_options[occupation].length);
+        let dialogue = dialogue_options[occupation][dialogue_index];
+
+        const adventurer = new Adventurer(name, occupation, dialogue);
+
         // Add adventurer to list of patrons
         shopPatrons.push(adventurer);
     }

--- a/client/src/utils/scenario_generator.js
+++ b/client/src/utils/scenario_generator.js
@@ -31,7 +31,7 @@ const names =
         'Leon',
         'Denton'
     ]
-}
+};
 
 const dialogue_options =
 {


### PR DESCRIPTION
### Shop Scenarios

- Upon page load, a random scenario featuring three different adventurers with randomly generated names/dialogue is created.
- The number of scenario patrons generated is based on the total number of potions the user has at page load.
- The player can either agree to sell a selected potion, or decline the offer if they choose.
- Once there are no patrons left in the scenario, then the page will automatically redirect to the main menu to conclude potion selling with `useNavigate`.